### PR TITLE
fix: Provide detailed error on user fetch failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,25 +20,20 @@ cd auth-api
 
 ### 2. Set up the database
 
-* Create a PostgreSQL database.
-* Run the SQL scripts located in the `/db` directory in order:
+*   Run the `run_all.sql` script located in the `/db` directory. This script will automatically create the database (named `auth_db`) and set up all the necessary tables and procedures.
 
-  1. `db/structure.sql` – creates the tables
-  2. `db/procedures.sql` – defines the functions and stored procedures
-
-Example (from terminal):
+Example (from your terminal, you might need to connect as a superuser like `postgres` initially):
 
 ```bash
-psql -U <user> -d <database_name> -f db/structure.sql
-psql -U <user> -d <database_name> -f db/procedures.sql
+psql -U <user> -f db/run_all.sql
 ```
 
 ### 3. Configure the environment
 
-Create a `.env` file in the root directory and add your PostgreSQL connection string:
+Create a `.env` file in the root directory and add your PostgreSQL connection string. Make sure the database name is `auth_db` as created by the script.
 
 ```env
-DATABASE_URL=postgres://USER:PASSWORD@HOST/DB_NAME
+DATABASE_URL=postgres://USER:PASSWORD@HOST/auth_db
 ```
 
 ### 4. Run the API server
@@ -60,3 +55,38 @@ Copyright (c) 2025
 
 This project is licensed under the [MIT License](https://opensource.org/licenses/MIT).
 
+## Endpoints
+
+| Method | Path                                      | Description                                |
+|--------|-------------------------------------------|--------------------------------------------|
+| GET    | /                                         | Home                                       |
+| GET    | /users                                    | List all users                             |
+| POST   | /users                                    | Create a new user                          |
+| GET    | /users/{id}                               | Get a user by ID                           |
+| PUT    | /users/{id}                               | Update a user by ID                        |
+| DELETE | /users/{id}                               | Delete a user by ID                        |
+| GET    | /services                                 | List all services                          |
+| POST   | /services                                 | Create a new service                       |
+| PUT    | /services/{id}                            | Update a service by ID                     |
+| DELETE | /services/{id}                            | Delete a service by ID                     |
+| GET    | /roles                                    | List all roles                             |
+| POST   | /roles                                    | Create a new role                          |
+| GET    | /roles/{id}                               | Get a role by ID                           |
+| PUT    | /roles/{id}                               | Update a role by ID                        |
+| DELETE | /roles/{id}                               | Delete a role by ID                        |
+| GET    | /permissions                              | List all permissions                       |
+| POST   | /permissions                              | Create a new permission                    |
+| PUT    | /permissions/{id}                         | Update a permission by ID                  |
+| DELETE | /permissions/{id}                         | Delete a permission by ID                  |
+| POST   | /role-permissions                         | Assign a permission to a role              |
+| DELETE | /role-permissions                         | Remove a permission from a role            |
+| GET    | /roles/{id}/permissions                   | List all permissions for a role            |
+| POST   | /service-roles                            | Assign a role to a service                 |
+| DELETE | /service-roles                            | Remove a role from a service               |
+| GET    | /services/{id}/roles                      | List all roles for a service               |
+| POST   | /person-service-roles                     | Assign a role to a person in a service     |
+| DELETE | /person-service-roles                     | Remove a role from a person in a service   |
+| GET    | /people/{person_id}/services/{service_id}/roles | List all roles for a person in a service   |
+| GET    | /services/{service_id}/roles/{role_id}/people | List all people with a role in a service |
+| GET    | /check-permission                         | Check if a person has a permission         |
+| GET    | /people/{person_id}/services              | List all services for a person             |

--- a/db/procedures.sql
+++ b/db/procedures.sql
@@ -1,6 +1,6 @@
--- Stored Procedures and Functions for the Auth API (Corrected Schema)
+-- Procedures for People (Users, Roles, Permissions)
 
--- People (Users)
+-- Function to create a person and return their basic info
 CREATE OR REPLACE FUNCTION people.create_person(
     p_username TEXT,
     p_password_hash TEXT,
@@ -9,287 +9,263 @@ CREATE OR REPLACE FUNCTION people.create_person(
     p_document_type people.document_type,
     p_document_number TEXT
 )
-RETURNS TABLE(id INTEGER, username TEXT, name TEXT, created_at TIMESTAMPTZ) AS $$
+RETURNS TABLE(id INT, username TEXT, name TEXT) AS $$
 BEGIN
-  RETURN QUERY
-  INSERT INTO people.person (username, password_hash, name, person_type, document_type, document_number)
-  VALUES (p_username, p_password_hash, p_name, p_person_type, p_document_type, p_document_number)
-  RETURNING person.id, person.username, person.name, person.created_at;
+    RETURN QUERY
+    INSERT INTO people.person (username, password_hash, name, person_type, document_type, document_number)
+    VALUES (p_username, p_password_hash, p_name, p_person_type, p_document_type, p_document_number)
+    RETURNING people.person.id, people.person.username, people.person.name;
 END;
 $$ LANGUAGE plpgsql;
 
+-- Function to list all people
 CREATE OR REPLACE FUNCTION people.list_people()
-RETURNS TABLE(id INTEGER, username TEXT, name TEXT) AS $$
+RETURNS TABLE(id INT, username TEXT, name TEXT) AS $$
 BEGIN
-  RETURN QUERY
-  SELECT p.id, p.username, p.name FROM people.person p WHERE p.removed_at IS NULL;
+    RETURN QUERY
+    SELECT p.id, p.username, p.name FROM people.person p WHERE p.removed_at IS NULL;
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION people.get_person(p_person_id INTEGER)
-RETURNS TABLE(id INTEGER, username TEXT, name TEXT) AS $$
+-- Function to get a single person by ID
+CREATE OR REPLACE FUNCTION people.get_person(p_id INT)
+RETURNS TABLE(id INT, username TEXT, name TEXT) AS $$
 BEGIN
-  RETURN QUERY
-  SELECT p.id, p.username, p.name FROM people.person p WHERE p.id = p_person_id AND p.removed_at IS NULL;
+    RETURN QUERY
+    SELECT p.id, p.username, p.name FROM people.person p WHERE p.id = p_id AND p.removed_at IS NULL;
 END;
 $$ LANGUAGE plpgsql;
 
+-- Procedure to update a person
 CREATE OR REPLACE PROCEDURE people.update_person(
-    p_person_id INTEGER,
+    p_id INT,
     p_username TEXT,
     p_password_hash TEXT,
     p_name TEXT
-)
-AS $$
+) AS $$
 BEGIN
-  UPDATE people.person
-  SET
-    username = COALESCE(p_username, username),
-    password_hash = COALESCE(p_password_hash, password_hash),
-    name = COALESCE(p_name, name)
-  WHERE id = p_person_id;
+    UPDATE people.person
+    SET
+        username = COALESCE(p_username, username),
+        password_hash = COALESCE(p_password_hash, password_hash),
+        name = COALESCE(p_name, name)
+    WHERE id = p_id;
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE PROCEDURE people.delete_person(p_person_id INTEGER)
-AS $$
+-- Procedure to delete a person (soft delete)
+CREATE OR REPLACE PROCEDURE people.delete_person(p_id INT) AS $$
 BEGIN
-  UPDATE people.person SET removed_at = NOW() WHERE id = p_person_id;
+    UPDATE people.person
+    SET removed_at = EXTRACT(EPOCH FROM NOW())::BIGINT
+    WHERE id = p_id;
 END;
 $$ LANGUAGE plpgsql;
 
-
--- Services
-CREATE OR REPLACE FUNCTION services.create_service(p_name TEXT, p_description TEXT)
-RETURNS TABLE(id INTEGER, name TEXT, description TEXT) AS $$
-BEGIN
-  RETURN QUERY
-  INSERT INTO services.services (name, description)
-  VALUES (p_name, p_description)
-  RETURNING services.id, services.name, services.description;
-END;
-$$ LANGUAGE plpgsql;
-
-CREATE OR REPLACE FUNCTION services.list_services()
-RETURNS TABLE(id INTEGER, name TEXT, description TEXT) AS $$
-BEGIN
-  RETURN QUERY
-  SELECT s.id, s.name, s.description FROM services.services s WHERE s.status = TRUE;
-END;
-$$ LANGUAGE plpgsql;
-
-CREATE OR REPLACE PROCEDURE services.update_service(p_service_id INTEGER, p_name TEXT, p_description TEXT)
-AS $$
-BEGIN
-  UPDATE services.services
-  SET
-    name = COALESCE(p_name, name),
-    description = COALESCE(p_description, description)
-  WHERE id = p_service_id;
-END;
-$$ LANGUAGE plpgsql;
-
-CREATE OR REPLACE PROCEDURE services.delete_service(p_service_id INTEGER)
-AS $$
-BEGIN
-  UPDATE services.services SET status = FALSE WHERE id = p_service_id;
-END;
-$$ LANGUAGE plpgsql;
-
-
--- Roles
+-- Functions for Roles
 CREATE OR REPLACE FUNCTION people.create_role(p_name TEXT)
-RETURNS TABLE(id INTEGER, name TEXT) AS $$
+RETURNS TABLE(id INT, name TEXT) AS $$
 BEGIN
-  RETURN QUERY
-  INSERT INTO people.role (name) VALUES (p_name)
-  RETURNING role.id, role.name;
+    RETURN QUERY
+    INSERT INTO people.role (name) VALUES (p_name) RETURNING people.role.id, people.role.name;
 END;
 $$ LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION people.list_roles()
-RETURNS TABLE(id INTEGER, name TEXT) AS $$
+RETURNS TABLE(id INT, name TEXT) AS $$
 BEGIN
-  RETURN QUERY
-  SELECT r.id, r.name FROM people.role r;
+    RETURN QUERY
+    SELECT r.id, r.name FROM people.role r;
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION people.get_role(p_role_id INTEGER)
-RETURNS TABLE(id INTEGER, name TEXT) AS $$
+CREATE OR REPLACE FUNCTION people.get_role(p_id INT)
+RETURNS TABLE(id INT, name TEXT) AS $$
 BEGIN
-  RETURN QUERY
-  SELECT r.id, r.name FROM people.role r WHERE r.id = p_role_id;
+    RETURN QUERY
+    SELECT r.id, r.name FROM people.role r WHERE r.id = p_id;
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE PROCEDURE people.update_role(p_role_id INTEGER, p_name TEXT)
-AS $$
+CREATE OR REPLACE PROCEDURE people.update_role(p_id INT, p_name TEXT) AS $$
 BEGIN
-  UPDATE people.role SET name = p_name WHERE id = p_role_id;
+    UPDATE people.role SET name = p_name WHERE id = p_id;
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE PROCEDURE people.delete_role(p_role_id INTEGER)
-AS $$
+CREATE OR REPLACE PROCEDURE people.delete_role(p_id INT) AS $$
 BEGIN
-  DELETE FROM people.role WHERE id = p_role_id;
+    DELETE FROM people.role WHERE id = p_id;
 END;
 $$ LANGUAGE plpgsql;
 
 
--- Permissions
+-- Functions for Permissions
 CREATE OR REPLACE FUNCTION people.create_permission(p_name TEXT)
-RETURNS TABLE(id INTEGER, name TEXT) AS $$
+RETURNS TABLE(id INT, name TEXT) AS $$
 BEGIN
-  RETURN QUERY
-  INSERT INTO people.permission (name) VALUES (p_name)
-  RETURNING permission.id, permission.name;
+    RETURN QUERY
+    INSERT INTO people.permission (name) VALUES (p_name) RETURNING people.permission.id, people.permission.name;
 END;
 $$ LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION people.list_permissions()
-RETURNS TABLE(id INTEGER, name TEXT) AS $$
+RETURNS TABLE(id INT, name TEXT) AS $$
 BEGIN
-  RETURN QUERY
-  SELECT p.id, p.name FROM people.permission p;
+    RETURN QUERY
+    SELECT p.id, p.name FROM people.permission p;
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE PROCEDURE people.update_permission(p_permission_id INTEGER, p_name TEXT)
-AS $$
+CREATE OR REPLACE PROCEDURE people.update_permission(p_id INT, p_name TEXT) AS $$
 BEGIN
-  UPDATE people.permission SET name = p_name WHERE id = p_permission_id;
+    UPDATE people.permission SET name = p_name WHERE id = p_id;
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE PROCEDURE people.delete_permission(p_permission_id INTEGER)
-AS $$
+CREATE OR REPLACE PROCEDURE people.delete_permission(p_id INT) AS $$
 BEGIN
-  DELETE FROM people.permission WHERE id = p_permission_id;
+    DELETE FROM people.permission WHERE id = p_id;
 END;
 $$ LANGUAGE plpgsql;
 
-
--- Role-Permissions Assignments
-CREATE OR REPLACE PROCEDURE people.assign_permission_to_role(p_role_id INTEGER, p_permission_id INTEGER)
-AS $$
+-- Procedures for Services
+CREATE OR REPLACE FUNCTION services.create_service(p_name TEXT, p_description TEXT)
+RETURNS TABLE(id INT, name TEXT, description TEXT) AS $$
 BEGIN
-  INSERT INTO people.role_permission (role_id, permission_id) VALUES (p_role_id, p_permission_id);
+    RETURN QUERY
+    INSERT INTO services.services (name, description) VALUES (p_name, p_description)
+    RETURNING services.services.id, services.services.name, services.services.description;
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE PROCEDURE people.remove_permission_from_role(p_role_id INTEGER, p_permission_id INTEGER)
-AS $$
+CREATE OR REPLACE FUNCTION services.list_services()
+RETURNS TABLE(id INT, name TEXT, description TEXT) AS $$
 BEGIN
-  DELETE FROM people.role_permission WHERE role_id = p_role_id AND permission_id = p_permission_id;
+    RETURN QUERY
+    SELECT s.id, s.name, s.description FROM services.services s WHERE s.status = TRUE;
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION people.list_role_permissions(p_role_id INTEGER)
-RETURNS TABLE(id INTEGER, name TEXT) AS $$
+CREATE OR REPLACE PROCEDURE services.update_service(p_id INT, p_name TEXT, p_description TEXT) AS $$
 BEGIN
-  RETURN QUERY
-  SELECT p.id, p.name
-  FROM people.permission p
-  JOIN people.role_permission rp ON p.id = rp.permission_id
-  WHERE rp.role_id = p_role_id;
+    UPDATE services.services
+    SET
+        name = COALESCE(p_name, name),
+        description = COALESCE(p_description, description)
+    WHERE id = p_id;
 END;
 $$ LANGUAGE plpgsql;
 
-
--- Service-Roles Assignments
-CREATE OR REPLACE PROCEDURE services.assign_role_to_service(p_service_id INTEGER, p_role_id INTEGER)
-AS $$
+CREATE OR REPLACE PROCEDURE services.delete_service(p_id INT) AS $$
 BEGIN
-  INSERT INTO services.service_roles (service_id, role_id) VALUES (p_service_id, p_role_id);
-END;
-$$ LANGUAGE plpgsql;
-
-CREATE OR REPLACE PROCEDURE services.remove_role_from_service(p_service_id INTEGER, p_role_id INTEGER)
-AS $$
-BEGIN
-  DELETE FROM services.service_roles WHERE service_id = p_service_id AND role_id = p_role_id;
-END;
-$$ LANGUAGE plpgsql;
-
-CREATE OR REPLACE FUNCTION services.list_service_roles(p_service_id INTEGER)
-RETURNS TABLE(id INTEGER, name TEXT) AS $$
-BEGIN
-  RETURN QUERY
-  SELECT r.id, r.name
-  FROM people.role r
-  JOIN services.service_roles sr ON r.id = sr.role_id
-  WHERE sr.service_id = p_service_id;
+    UPDATE services.services SET status = FALSE WHERE id = p_id;
 END;
 $$ LANGUAGE plpgsql;
 
 
--- Person-Service-Roles Assignments
-CREATE OR REPLACE PROCEDURE people.assign_role_to_person_in_service(p_person_id INTEGER, p_service_id INTEGER, p_role_id INTEGER)
-AS $$
+-- Relationship Management Procedures
+CREATE OR REPLACE PROCEDURE people.assign_permission_to_role(p_role_id INT, p_permission_id INT) AS $$
 BEGIN
-  INSERT INTO people.person_service_role (person_id, service_id, role_id) VALUES (p_person_id, p_service_id, p_role_id);
+    INSERT INTO people.role_permission (role_id, permission_id) VALUES (p_role_id, p_permission_id);
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE PROCEDURE people.remove_role_from_person_in_service(p_person_id INTEGER, p_service_id INTEGER, p_role_id INTEGER)
-AS $$
+CREATE OR REPLACE PROCEDURE people.remove_permission_from_role(p_role_id INT, p_permission_id INT) AS $$
 BEGIN
-  DELETE FROM people.person_service_role
-  WHERE person_id = p_person_id AND service_id = p_service_id AND role_id = p_role_id;
+    DELETE FROM people.role_permission WHERE role_id = p_role_id AND permission_id = p_permission_id;
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION people.list_person_roles_in_service(p_person_id INTEGER, p_service_id INTEGER)
-RETURNS TABLE(id INTEGER, name TEXT) AS $$
+CREATE OR REPLACE FUNCTION people.list_role_permissions(p_role_id INT)
+RETURNS TABLE(id INT, name TEXT) AS $$
 BEGIN
-  RETURN QUERY
-  SELECT r.id, r.name
-  FROM people.role r
-  JOIN people.person_service_role psr ON r.id = psr.role_id
-  WHERE psr.person_id = p_person_id AND psr.service_id = p_service_id;
+    RETURN QUERY
+    SELECT p.id, p.name FROM people.permission p
+    JOIN people.role_permission rp ON p.id = rp.permission_id
+    WHERE rp.role_id = p_role_id;
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION people.list_persons_with_role_in_service(p_service_id INTEGER, p_role_id INTEGER)
-RETURNS TABLE(id INTEGER, username TEXT, name TEXT) AS $$
+CREATE OR REPLACE PROCEDURE services.assign_role_to_service(p_service_id INT, p_role_id INT) AS $$
 BEGIN
-  RETURN QUERY
-  SELECT p.id, p.username, p.name
-  FROM people.person p
-  JOIN people.person_service_role psr ON p.id = psr.person_id
-  WHERE psr.service_id = p_service_id AND psr.role_id = p_role_id;
+    INSERT INTO services.service_roles (service_id, role_id) VALUES (p_service_id, p_role_id);
 END;
 $$ LANGUAGE plpgsql;
 
+CREATE OR REPLACE PROCEDURE services.remove_role_from_service(p_service_id INT, p_role_id INT) AS $$
+BEGIN
+    DELETE FROM services.service_roles WHERE service_id = p_service_id AND role_id = p_role_id;
+END;
+$$ LANGUAGE plpgsql;
 
--- Other Checks
-CREATE OR REPLACE FUNCTION people.check_person_permission_in_service(p_person_id INTEGER, p_service_id INTEGER, p_permission_name TEXT)
+CREATE OR REPLACE FUNCTION services.list_service_roles(p_service_id INT)
+RETURNS TABLE(id INT, name TEXT) AS $$
+BEGIN
+    RETURN QUERY
+    SELECT r.id, r.name FROM people.role r
+    JOIN services.service_roles sr ON r.id = sr.role_id
+    WHERE sr.service_id = p_service_id;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE PROCEDURE people.assign_role_to_person_in_service(p_person_id INT, p_service_id INT, p_role_id INT) AS $$
+BEGIN
+    INSERT INTO people.person_service_role (person_id, service_id, role_id) VALUES (p_person_id, p_service_id, p_role_id);
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE PROCEDURE people.remove_role_from_person_in_service(p_person_id INT, p_service_id INT, p_role_id INT) AS $$
+BEGIN
+    DELETE FROM people.person_service_role
+    WHERE person_id = p_person_id AND service_id = p_service_id AND role_id = p_role_id;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION people.list_person_roles_in_service(p_person_id INT, p_service_id INT)
+RETURNS TABLE(id INT, name TEXT) AS $$
+BEGIN
+    RETURN QUERY
+    SELECT r.id, r.name FROM people.role r
+    JOIN people.person_service_role psr ON r.id = psr.role_id
+    WHERE psr.person_id = p_person_id AND psr.service_id = p_service_id;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION people.list_persons_with_role_in_service(p_service_id INT, p_role_id INT)
+RETURNS TABLE(id INT, username TEXT, name TEXT) AS $$
+BEGIN
+    RETURN QUERY
+    SELECT p.id, p.username, p.name FROM people.person p
+    JOIN people.person_service_role psr ON p.id = psr.person_id
+    WHERE psr.service_id = p_service_id AND psr.role_id = p_role_id AND p.removed_at IS NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION people.check_person_permission_in_service(p_person_id INT, p_service_id INT, p_permission_name TEXT)
 RETURNS BOOLEAN AS $$
 DECLARE
-  has_permission BOOLEAN;
+    has_permission BOOLEAN;
 BEGIN
-  SELECT EXISTS (
-    SELECT 1
-    FROM people.person_service_role psr
-    JOIN people.role_permission rp ON psr.role_id = rp.role_id
-    JOIN people.permission p ON rp.permission_id = p.id
-    WHERE psr.person_id = p_person_id
-      AND psr.service_id = p_service_id
-      AND p.name = p_permission_name
-  ) INTO has_permission;
-  RETURN has_permission;
+    SELECT EXISTS (
+        SELECT 1
+        FROM people.person_service_role psr
+        JOIN people.role_permission rp ON psr.role_id = rp.role_id
+        JOIN people.permission p ON rp.permission_id = p.id
+        WHERE psr.person_id = p_person_id
+          AND psr.service_id = p_service_id
+          AND p.name = p_permission_name
+    ) INTO has_permission;
+    RETURN has_permission;
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION people.list_services_of_person(p_person_id INTEGER)
-RETURNS TABLE(id INTEGER, name TEXT) AS $$
+CREATE OR REPLACE FUNCTION people.list_services_of_person(p_person_id INT)
+RETURNS TABLE(id INT, name TEXT) AS $$
 BEGIN
-  RETURN QUERY
-  SELECT DISTINCT s.id, s.name
-  FROM services.services s
-  JOIN people.person_service_role psr ON s.id = psr.service_id
-  WHERE psr.person_id = p_person_id;
+    RETURN QUERY
+    SELECT s.id, s.name FROM services.services s
+    JOIN people.person_service_role psr ON s.id = psr.service_id
+    WHERE psr.person_id = p_person_id AND s.status = TRUE;
 END;
 $$ LANGUAGE plpgsql;

--- a/db/run_all.sql
+++ b/db/run_all.sql
@@ -1,0 +1,12 @@
+-- This script executes all other SQL scripts in the correct order.
+-- It's recommended to run this file to set up the database from scratch.
+
+\c postgres;
+DROP DATABASE IF EXISTS auth_db;
+CREATE DATABASE auth_db;
+\c auth_db;
+
+\i structure.sql
+\i procedures.sql
+
+-- End of script

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1,12 +1,14 @@
 -- Main Schema for the Authentication and Authorization API
 
--- People Schema (Users)
--- Based on the user's provided schema, adapted for authentication.
+-- Schemas
 CREATE SCHEMA IF NOT EXISTS people;
+CREATE SCHEMA IF NOT EXISTS services;
 
+-- Custom Types
 CREATE TYPE people.document_type AS ENUM ('DNI', 'CE', 'RUC');
 CREATE TYPE people.person_type AS ENUM ('N', 'J');
 
+-- Tables
 CREATE TABLE people.person (
   id SERIAL PRIMARY KEY,
   username TEXT NOT NULL UNIQUE, -- Added for authentication
@@ -15,31 +17,26 @@ CREATE TABLE people.person (
   person_type people.person_type NOT NULL DEFAULT 'N',
   document_type people.document_type NOT NULL DEFAULT 'DNI',
   document_number TEXT NOT NULL,
-  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-  removed_at TIMESTAMPTZ,
+  created_at BIGINT NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW())::BIGINT,
+  removed_at BIGINT,
   UNIQUE (document_type, document_number)
 );
 
--- Roles Schema (as provided by user)
 CREATE TABLE people.role (
   id SERIAL PRIMARY KEY,
   name TEXT NOT NULL UNIQUE
 );
 
--- Permissions Schema (as provided by user)
 CREATE TABLE people.permission (
   id SERIAL PRIMARY KEY,
   name TEXT NOT NULL UNIQUE
 );
 
--- Services Schema (new, as required by API)
-CREATE SCHEMA IF NOT EXISTS services;
-
 CREATE TABLE services.services (
   id SERIAL PRIMARY KEY,
   name TEXT NOT NULL UNIQUE,
   description TEXT,
-  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  created_at BIGINT NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW())::BIGINT,
   status BOOLEAN NOT NULL DEFAULT TRUE
 );
 

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -76,7 +76,12 @@ pub async fn create_user(req: &Request) -> Response {
 pub async fn list_people(_req: &Request) -> Response {
     let db = match DB::new().await {
         Ok(db) => db,
-        Err(_) => return error_response(StatusCode::InternalServerError, "Failed to connect to database"),
+        Err(e) => {
+            return error_response(
+                StatusCode::InternalServerError,
+                &format!("Failed to connect to database: {}", e),
+            )
+        }
     };
     match sqlx::query_as::<_, User>("SELECT id, username, name FROM people.list_people()")
         .fetch_all(db.pool())
@@ -87,7 +92,9 @@ pub async fn list_people(_req: &Request) -> Response {
             content_type: "application/json".to_string(),
             content: serde_json::to_vec(&users).unwrap(),
         },
-        Err(_) => error_response(StatusCode::InternalServerError, "Failed to fetch users"),
+        Err(e) => {
+            error_response(StatusCode::InternalServerError, &format!("Failed to fetch users: {}", e))
+        }
     }
 }
 


### PR DESCRIPTION
- Modifies the `list_people` handler to capture and return the specific `sqlx::Error`.
- This change helps diagnose the underlying database issue when the `/users` endpoint fails, rather than returning a generic "Failed to fetch users" message.