### PR TITLE
Fix database setup scripts for user queries

### DIFF
--- a/db/demo_data.sql
+++ b/db/demo_data.sql
@@ -1,53 +1,98 @@
-INSERT INTO services (name)
-VALUES
-  ('Service A'),
-  ('Service B'),
-  ('Service C');
+-- Demo seed data for the auth API database.
+-- All inserts use ON CONFLICT safeguards so the script can be run multiple times.
 
-INSERT INTO people.roles (name)
+\set ON_ERROR_STOP on
+
+-- Services
+INSERT INTO services.services (name, description)
+VALUES
+  ('Service A', 'Demo catalog service'),
+  ('Service B', 'Internal billing service'),
+  ('Service C', 'Customer support portal')
+ON CONFLICT (name) DO NOTHING;
+
+-- Roles
+INSERT INTO people.role (name)
 VALUES
   ('Admin'),
   ('User'),
   ('Editor'),
-  ('Viewer');
+  ('Viewer')
+ON CONFLICT (name) DO NOTHING;
 
-INSERT INTO people.permissions (name)
+-- Permissions
+INSERT INTO people.permission (name)
 VALUES
   ('read'),
   ('write'),
   ('update'),
   ('delete'),
-  ('share');
+  ('share')
+ON CONFLICT (name) DO NOTHING;
 
-INSERT INTO people.people (username, password_hash)
+-- People
+INSERT INTO people.person (
+  username,
+  password_hash,
+  name,
+  person_type,
+  document_type,
+  document_number
+)
 VALUES
-  ('adm1', crypt('adm1', gen_salt('bf'))),
-  ('usr1', crypt('usr1', gen_salt('bf'))),
-  ('usr2', crypt('usr2', gen_salt('bf'))),
-  ('usr3', crypt('usr3', gen_salt('bf'))),
-  ('editor1', crypt('editor1', gen_salt('bf'))),
-  ('viewer1', crypt('viewer1', gen_salt('bf')));
+  ('adm1', 'adm1-hash', 'Admin One', 'N', 'DNI', '00000001'),
+  ('usr1', 'usr1-hash', 'User One', 'N', 'DNI', '00000002'),
+  ('usr2', 'usr2-hash', 'User Two', 'N', 'DNI', '00000003'),
+  ('usr3', 'usr3-hash', 'User Three', 'N', 'DNI', '00000004'),
+  ('editor1', 'editor1-hash', 'Editor One', 'N', 'DNI', '00000005'),
+  ('viewer1', 'viewer1-hash', 'Viewer One', 'N', 'DNI', '00000006')
+ON CONFLICT (username) DO NOTHING;
 
-INSERT INTO people.role_permissions (role_id, permission_id)
-VALUES
-  (1, 1),
-  (1, 2),
-  (1, 3),
-  (1, 4),
-  (2, 1),
-  (3, 5),
-  (4, 6);
+-- Role permissions
+WITH role_permission_pairs (role_name, permission_name) AS (
+  VALUES
+    ('Admin', 'read'),
+    ('Admin', 'write'),
+    ('Admin', 'update'),
+    ('Admin', 'delete'),
+    ('User', 'read'),
+    ('Editor', 'update'),
+    ('Viewer', 'read')
+)
+INSERT INTO people.role_permission (role_id, permission_id)
+SELECT r.id, p.id
+FROM role_permission_pairs rp
+JOIN people.role r ON r.name = rp.role_name
+JOIN people.permission p ON p.name = rp.permission_name
+ON CONFLICT (role_id, permission_id) DO NOTHING;
 
-INSERT INTO people.service_roles (service_id, role_id)
-VALUES
-  (1, 1),
-  (1, 2),
-  (2, 2),
-  (3, 3);
+-- Service roles
+WITH service_role_pairs (service_name, role_name) AS (
+  VALUES
+    ('Service A', 'Admin'),
+    ('Service A', 'User'),
+    ('Service B', 'User'),
+    ('Service C', 'Editor')
+)
+INSERT INTO services.service_roles (service_id, role_id)
+SELECT s.id, r.id
+FROM service_role_pairs sr
+JOIN services.services s ON s.name = sr.service_name
+JOIN people.role r ON r.name = sr.role_name
+ON CONFLICT (service_id, role_id) DO NOTHING;
 
-INSERT INTO people.person_service_roles (person_id, service_id, role_id)
-VALUES
-  (1, 1, 1),
-  (2, 1, 2),
-  (3, 2, 2),
-  (4, 3, 3);
+-- Person assignments to service roles
+WITH person_service_role_pairs (username, service_name, role_name) AS (
+  VALUES
+    ('adm1', 'Service A', 'Admin'),
+    ('usr1', 'Service A', 'User'),
+    ('usr2', 'Service B', 'User'),
+    ('usr3', 'Service C', 'Editor')
+)
+INSERT INTO people.person_service_role (person_id, service_id, role_id)
+SELECT pe.id, s.id, r.id
+FROM person_service_role_pairs psr
+JOIN people.person pe ON pe.username = psr.username
+JOIN services.services s ON s.name = psr.service_name
+JOIN people.role r ON r.name = psr.role_name
+ON CONFLICT (person_id, service_id, role_id) DO NOTHING;

--- a/db/run_all.sql
+++ b/db/run_all.sql
@@ -1,12 +1,27 @@
 -- This script executes all other SQL scripts in the correct order.
 -- It's recommended to run this file to set up the database from scratch.
 
+\set ON_ERROR_STOP on
+
+\echo 'Connecting to postgres database...'
 \c postgres;
+
+\echo 'Recreating auth_db database...'
 DROP DATABASE IF EXISTS auth_db;
 CREATE DATABASE auth_db;
+
+\echo 'Switching connection to auth_db...'
 \c auth_db;
 
-\i structure.sql
-\i procedures.sql
+\echo 'Loading database structure...'
+\ir structure.sql
+
+\echo 'Loading stored procedures...'
+\ir procedures.sql
+
+-- Uncomment the next line if you also want to load the demo data.
+-- \ir demo_data.sql
+
+\echo 'Database setup completed successfully.'
 
 -- End of script

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -54,7 +54,7 @@ pub async fn create_user(req: &Request) -> Response {
     let document_type: people::DocumentType = serde_json::from_str(&format!("\"{}\"", payload.document_type)).unwrap_or(people::DocumentType::DNI);
 
     match sqlx::query_as::<_, User>(
-        "SELECT id, username, name FROM people.create_person($1, $2, $3, $4, $5, $6)")
+        "SELECT * FROM people.create_person($1, $2, $3, $4, $5, $6)")
         .bind(payload.username)
         .bind(payload.password_hash)
         .bind(payload.name)
@@ -83,7 +83,7 @@ pub async fn list_people(_req: &Request) -> Response {
             )
         }
     };
-    match sqlx::query_as::<_, User>("SELECT id, username, name FROM people.list_people()")
+    match sqlx::query_as::<_, User>("SELECT * FROM people.list_people()")
         .fetch_all(db.pool())
         .await
     {
@@ -107,7 +107,7 @@ pub async fn get_user(req: &Request) -> Response {
         Some(id) => id,
         None => return error_response(StatusCode::BadRequest, "Invalid user ID"),
     };
-    match sqlx::query_as::<_, User>("SELECT id, username, name FROM people.get_person($1)")
+    match sqlx::query_as::<_, User>("SELECT * FROM people.get_person($1)")
         .bind(id)
         .fetch_optional(db.pool())
         .await
@@ -796,7 +796,7 @@ pub async fn list_persons_with_role_in_service(req: &Request) -> Response {
         Some(id) => id,
         None => return error_response(StatusCode::BadRequest, "Invalid role ID"),
     };
-    match sqlx::query_as::<_, User>("SELECT id, username, name FROM people.list_persons_with_role_in_service($1, $2)")
+    match sqlx::query_as::<_, User>("SELECT * FROM people.list_persons_with_role_in_service($1, $2)")
         .bind(service_id)
         .bind(role_id)
         .fetch_all(db.pool())
@@ -852,7 +852,8 @@ pub async fn list_services_of_person(req: &Request) -> Response {
         Some(id) => id,
         None => return error_response(StatusCode::BadRequest, "Invalid person ID"),
     };
-    match sqlx::query_as::<_, Service>("SELECT id, name, NULL as description FROM people.list_services_of_person($1)")
+    match sqlx::query_as::<_, Service>(
+        "SELECT s.id, s.name, NULL::TEXT AS description FROM people.list_services_of_person($1) AS s")
         .bind(person_id)
         .fetch_all(db.pool())
         .await


### PR DESCRIPTION
## Summary
- ensure the setup script stops on errors, includes structure/procedure files relative to its directory, and emits clear progress messages when recreating the database
- refresh the demo data to match the current schema and insert relationships idempotently
- adjust API user/service queries to call the Postgres set-returning functions correctly so list endpoints work against the seeded database

## Testing
- not run (database connection required)

------
https://chatgpt.com/codex/tasks/task_e_68e756d549308329b9b841c66f21cd53